### PR TITLE
[Feature/Solid] Explain  Open/Closed Principle (OCP)

### DIFF
--- a/Solid/OpenClosePrinciple/After-OCP.swift
+++ b/Solid/OpenClosePrinciple/After-OCP.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+enum Color {
+    case red, green, orange
+}
+
+enum Size {
+    case small, medium, large
+}
+
+struct Product {
+    var name: String
+    var color: Color
+    var size: Size
+}
+
+// MARK: - Specifications
+
+// The Specification protocol allows the creation of new conditions without modifying existing code.
+// This satisfies the Open/Closed Principle as new filtering criteria can be added by creating new implementations of this protocol.
+
+protocol Specification {
+    associatedtype T
+    func isSatisfied(_ item: T) -> Bool
+}
+
+// Concrete specification for filtering by color
+struct ColorSpecification: Specification {
+    typealias T = Product
+    let color: Color
+
+    func isSatisfied(_ item: T) -> Bool {
+        return item.color == self.color
+    }
+}
+
+// Concrete specification for filtering by size
+struct SizeSpecification: Specification {
+    typealias T = Product
+    let size: Size
+
+    func isSatisfied(_ item: T) -> Bool {
+        return item.size == self.size
+    }
+}
+
+// Composite specification to combine multiple conditions using generics
+struct AndSpecification<T, 
+    SpecA: Specification,
+    SpecB: Specification> : Specification where SpecA.T == SpecB.T, SpecA.T == T, SpecA.T == T {
+    let firstSpec: SpecA
+    let secondSpec: SpecB
+
+    func isSatisfied(_ item: T) -> Bool {
+        return firstSpec.isSatisfied(item) && secondSpec.isSatisfied(item)
+    }
+}
+
+// MARK: - Filter
+
+// The Filter protocol defines a method to filter items based on a specification.
+// The ProductFilter class implements this protocol, allowing it to filter products by any specification.
+
+protocol Filter {
+    associatedtype T
+    func filter<Spec: Specification>(_ items: [T], spec: Spec) -> [T] where Spec.T == T
+}
+
+struct ProductFilter: Filter {
+    typealias T = Product
+
+    func filter<Spec: Specification>(_ items: [T], spec: Spec) -> [T] where Spec.T == T {
+        return items.filter { spec.isSatisfied($0) }
+    }
+}
+
+// MARK: - Execute
+
+func main() {
+    let chilly = Product(name: "Chilly", color: .green, size: .small)
+    let apple = Product(name: "Apple", color: .red, size: .small)
+    let jackfruit = Product(name: "Jackfruit", color: .green, size: .medium)
+    let pumkin = Product(name: "Pumkin", color: .orange, size: .large)
+    let coriander = Product(name: "Coriander", color: .green, size: .small)
+
+    let allProducts = [ chilly, apple, jackfruit, pumkin, coriander]
+    print("All products:")
+    allProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    let filter = ProductFilter()
+
+    // Filtering by color using the OCP-compliant approach
+    let orangeColorSpec = ColorSpecification(color: .orange)
+    let orangeProducts = filter.filter(allProducts, spec: orangeColorSpec)
+    print("\nAll orange products:")
+    orangeProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    // Filtering by size using the OCP-compliant approach
+    let smallSizeSpec = SizeSpecification(size: .small)
+    let smallProducts = filter.filter(allProducts, spec: smallSizeSpec)
+    print("\nAll small products:")
+    smallProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    // Filtering by a combination of color and size using the OCP-compliant approach
+    let smallAndGreenProdSpec = AndSpecification(
+        firstSpec: SizeSpecification(size: .small), 
+        secondSpec: ColorSpecification(color: .green))
+    let smallAndGreenProducts = filter.filter(allProducts, spec: smallAndGreenProdSpec)
+    print("\nAll small green products:")
+    smallAndGreenProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+}
+
+main()

--- a/Solid/OpenClosePrinciple/Before-OCP.swift
+++ b/Solid/OpenClosePrinciple/Before-OCP.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum Color {
+    case red
+    case orange
+    case green
+}
+
+enum Size {
+    case small, medium, large
+}
+
+struct Product {
+    var name: String
+    var color: Color
+    var size: Size
+}
+
+// The ProductFilter class violates the Open/Closed Principle
+// because it needs to be modified whenever a new filter condition is added.
+// This class has methods for filtering by color, size, and a combination of both.
+// Any new filtering criteria would require changing the code here, thus it's not "closed for modification".
+
+class ProductFilter {
+    func filterByColor(_ products: [Product], color: Color) -> [Product] {
+        return products.filter { $0.color == color }
+    }
+
+    func filterBySize(_ products: [Product], size: Size) -> [Product] {
+        return products.filter { $0.size == size }
+    }
+
+    func filterByColorAndSize(_ products: [Product], color: Color, size: Size) -> [Product] {
+        return products.filter { $0.color == color && $0.size == size }
+    }
+}
+
+// MARK: - Execute
+
+func main() {
+    let chilly = Product(name: "Chilly", color: .green, size: .small)
+    let apple = Product(name: "Apple", color: .red, size: .small)
+    let jackfruit = Product(name: "Jackfruit", color: .green, size: .medium)
+    let pumkin = Product(name: "Pumkin", color: .orange, size: .large)
+    let coriander = Product(name: "Coriander", color: .green, size: .small)
+
+    let allProducts = [ chilly, apple, jackfruit, pumkin, coriander]
+    print("All products:")
+    allProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    let filter = ProductFilter()
+
+    // Filtering by color
+    let orangeProducts = filter.filterByColor(allProducts, color: .orange)
+    print("\nAll orange products:")
+    orangeProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    // Filtering by size
+    let smallProducts = filter.filterBySize(allProducts, size: .small)
+    print("\nAll small products:")
+    smallProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+
+    // Filtering by color and size
+    let smallGreenProducts = filter.filterByColorAndSize(allProducts, color: .green, size: .small)
+    print("\nAll small green products:")
+    smallGreenProducts.forEach {
+        print("- \($0.name) is \($0.color) and \($0.size)")
+    }
+}
+
+main()

--- a/Solid/OpenClosePrinciple/ReadMe.md
+++ b/Solid/OpenClosePrinciple/ReadMe.md
@@ -1,0 +1,23 @@
+# Open/Closed Principle (OCP)
+
+## Introduction
+
+The Open/Closed Principle (OCP) is one of the five SOLID principles of object-oriented design. It states that software entities (classes, modules, functions, etc.) should be **open for extension, but closed for modification**. This means that the behavior of a module should be extendable without modifying its source code, thus reducing the risk of introducing new bugs into existing functionality.
+
+## Before Applying OCP
+
+In the `Before-OCP.swift` file, we have a `ProductFilter` class that violates the Open/Closed Principle. The class has methods for filtering products by color, size, and a combination of both. If we need to add a new filtering criterion (e.g., by weight, material, etc.), we would need to modify the `ProductFilter` class, which increases the risk of breaking existing functionality.
+
+## After Applying OCP
+
+In the `After-OCP.swift` file, the code has been refactored to follow the Open/Closed Principle. We introduced the `Specification` protocol, which allows us to create new filter criteria without modifying the existing `ProductFilter` class. The filtering logic is now encapsulated within specific implementations of the `Specification` protocol (e.g., `ColorSpecification`, `SizeSpecification`). We also demonstrated how to combine multiple specifications using generics and composite specifications (`AndSpecification`).
+
+### Key Benefits
+
+- **Extensibility**: We can add new filtering criteria by creating new specifications without changing the `ProductFilter` class.
+- **Maintainability**: Since we don't modify existing code, we reduce the risk of introducing bugs.
+- **Reusability**: The specifications can be reused in different parts of the codebase or combined in various ways to create complex filtering logic.
+
+## Conclusion
+
+The Open/Closed Principle encourages writing code that is easy to extend with new features while ensuring that the existing code remains stable and unchanged. By following this principle, we create software that is more flexible, maintainable, and resilient to change.


### PR DESCRIPTION
- Added `Before-OCP.swift` demonstrating violation of OCP with ProductFilter class.
- Created `After-OCP.swift` implementing OCP using Specification and Filter patterns.
- Updated filtering logic to be extendable without modifying existing code.
- Added `ReadMe.md` to explain OCP, before/after changes, and benefits of the new design.

This commit illustrates the benefits of OCP by providing a clear before-and-after comparison.