### PR TITLE
[Feature/Solid] Explain Liskov's Substitution Principle

### DIFF
--- a/Solid/LiskovSubstitutionPrinciple/After-LSP.swift
+++ b/Solid/LiskovSubstitutionPrinciple/After-LSP.swift
@@ -13,11 +13,11 @@ protocol Flyable {
 // Sparrow class conforming to Bird and Flyable
 class Sparrow: Bird, Flyable {
     var name: String
-    
+
     init(name: String) {
         self.name = name
     }
-    
+
     // Sparrow can fly, so the fly method is implemented here
     func fly() -> String {
         return "\(name) is flying."
@@ -27,11 +27,11 @@ class Sparrow: Bird, Flyable {
 // Penguin class conforming only to Bird
 class Penguin: Bird {
     var name: String
-    
+
     init(name: String) {
         self.name = name
     }
-    
+
     // Penguins do not conform to Flyable, so they don't implement fly().
     // This design naturally reflects the real-world behavior of penguins.
 }

--- a/Solid/LiskovSubstitutionPrinciple/After-LSP.swift
+++ b/Solid/LiskovSubstitutionPrinciple/After-LSP.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// Base protocol representing generic bird behavior
+protocol Bird {
+    var name: String { get }
+}
+
+// Separate protocol for birds that can fly
+protocol Flyable {
+    func fly() -> String
+}
+
+// Sparrow class conforming to Bird and Flyable
+class Sparrow: Bird, Flyable {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    // Sparrow can fly, so the fly method is implemented here
+    func fly() -> String {
+        return "\(name) is flying."
+    }
+}
+
+// Penguin class conforming only to Bird
+class Penguin: Bird {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    // Penguins do not conform to Flyable, so they don't implement fly().
+    // This design naturally reflects the real-world behavior of penguins.
+}
+
+// Function to make birds fly, but only for those that are Flyable
+func makeBirdFly(bird: Bird & Flyable) {
+    // Since the function only accepts Bird types that are Flyable,
+    // it adheres to LSP by ensuring that any passed bird can indeed fly.
+    print(bird.fly())
+}
+
+// Usage
+let sparrow = Sparrow(name: "Sparrow")
+let penguin = Penguin(name: "Penguin")
+
+makeBirdFly(bird: sparrow)  // Output: Sparrow is flying.
+// makeBirdFly(bird: penguin) // This would cause a compile-time error, preventing misuse.

--- a/Solid/LiskovSubstitutionPrinciple/Before-LSP.swift
+++ b/Solid/LiskovSubstitutionPrinciple/Before-LSP.swift
@@ -3,11 +3,11 @@ import Foundation
 // Base class representing a generic bird
 class Bird {
     var name: String
-    
+
     init(name: String) {
         self.name = name
     }
-    
+
     // Method to make the bird fly
     // LSP Violation: The base class assumes that all birds can fly,
     // but this is not true for all bird species (e.g., penguins).

--- a/Solid/LiskovSubstitutionPrinciple/Before-LSP.swift
+++ b/Solid/LiskovSubstitutionPrinciple/Before-LSP.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// Base class representing a generic bird
+class Bird {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    // Method to make the bird fly
+    // LSP Violation: The base class assumes that all birds can fly,
+    // but this is not true for all bird species (e.g., penguins).
+    func fly() -> String {
+        return "\(name) is flying."
+    }
+}
+
+// Subclass representing a Sparrow, a type of bird that can fly
+class Sparrow: Bird {
+    // Inherits fly() method from Bird, which is appropriate for sparrows
+}
+
+// Subclass representing a Penguin, a type of bird that cannot fly
+class Penguin: Bird {
+    // LSP Violation: Penguins cannot fly, so this method should not exist.
+    // However, due to inheritance, the Penguin class is forced to override 
+    // the fly() method, leading to a design that doesn't make sense.
+    override func fly() -> String {
+        // Inappropriate implementation for a penguin, 
+        // possibly leading to errors or misuse.
+        return "\(name) cannot fly."
+    }
+}
+
+// Function to make birds fly
+func makeBirdFly(bird: Bird) {
+    // LSP Violation: This function expects any Bird to be able to fly,
+    // but if a Penguin is passed, the behavior is not as expected.
+    print(bird.fly())
+}
+
+// Usage
+let sparrow = Sparrow(name: "Sparrow")
+let penguin = Penguin(name: "Penguin")
+
+makeBirdFly(bird: sparrow)  // Output: Sparrow is flying.
+makeBirdFly(bird: penguin)  // Output: Penguin cannot fly (unexpected behavior).

--- a/Solid/LiskovSubstitutionPrinciple/ReadMe.md
+++ b/Solid/LiskovSubstitutionPrinciple/ReadMe.md
@@ -10,13 +10,13 @@ In `Before-LSP.swift`, the `Bird` class is designed to represent any bird, with 
 
 ## After-LSP.swift
 To adhere to the Liskov Substitution Principle, `After-LSP.swift` refactors the design:
-- `Bird` is now a protocol, and `FlyingBird` is a protocol that extends `Bird` with a `fly()` method.
-- `Sparrow` conforms to `FlyingBird`, as it can fly.
+- `Bird` is now a protocol, and `Flyable` is a protocol with a `fly()` method.
+- `Sparrow` conforms to `Bird` and `Flyable`, indicating it a bird which can fly.
 - `Penguin` conforms only to `Bird`, as it does not have the ability to fly.
 
-This design ensures that any bird that can fly will conform to `FlyingBird`, and any function expecting a flying bird can safely assume that the bird can indeed fly.
+This design ensures that any bird that can fly will conform to `Flyable`, and any function expecting a flying bird can safely assume that the bird can indeed fly.
 
 ## Overview of Changes
-- Introduced a `Bird` protocol for common bird behaviors and a `FlyingBird` protocol for birds that can fly.
-- `Sparrow` conforms to `FlyingBird`, ensuring that it can be treated as a flying bird.
+- Introduced a `Bird` protocol for common bird behaviors and a `Flyable` protocol for birds that can fly.
+- `Sparrow` conforms to `Bird` & `Flyable` protocols, ensuring that it can be treated as a flying bird.
 - `Penguin` conforms only to `Bird`, avoiding the incorrect assumption that it can fly.

--- a/Solid/LiskovSubstitutionPrinciple/ReadMe.md
+++ b/Solid/LiskovSubstitutionPrinciple/ReadMe.md
@@ -1,0 +1,22 @@
+# Liskov Substitution Principle (LSP)
+
+## What is the Liskov Substitution Principle?
+The Liskov Substitution Principle (LSP) is one of the SOLID principles of object-oriented design. It suggests that objects of a superclass should be replaceable with objects of a subclass without altering the correct behavior of the program.
+
+In simpler terms, if you have a function that works with a base class, it should work with any subclass of that base class without any issues.
+
+## Before-LSP.swift
+In `Before-LSP.swift`, the `Bird` class is designed to represent any bird, with a `fly()` method that indicates the bird can fly. However, `Penguin`, which is a subclass of `Bird`, cannot fly and overrides the `fly()` method to return a different behavior. This breaks the LSP because `Penguin` cannot be used as a `Bird` in contexts where flying is expected.
+
+## After-LSP.swift
+To adhere to the Liskov Substitution Principle, `After-LSP.swift` refactors the design:
+- `Bird` is now a protocol, and `FlyingBird` is a protocol that extends `Bird` with a `fly()` method.
+- `Sparrow` conforms to `FlyingBird`, as it can fly.
+- `Penguin` conforms only to `Bird`, as it does not have the ability to fly.
+
+This design ensures that any bird that can fly will conform to `FlyingBird`, and any function expecting a flying bird can safely assume that the bird can indeed fly.
+
+## Overview of Changes
+- Introduced a `Bird` protocol for common bird behaviors and a `FlyingBird` protocol for birds that can fly.
+- `Sparrow` conforms to `FlyingBird`, ensuring that it can be treated as a flying bird.
+- `Penguin` conforms only to `Bird`, avoiding the incorrect assumption that it can fly.


### PR DESCRIPTION
- Added 'Before-LSP.swift' demonstrating violation of LSP with Bird hierarchy.
- Created 'After-LSP.swift' adhering to LSP by refactoring Bird hierarchy.
- Updated inheritance structure to ensure derived classes can be substituted for their base class.
- Added 'ReadMe.md' to explain LSP, before/after changes, and the importance of maintaining LSP in design.