### PR TITLE
[Feature/Solid] Explain Interface Segregation Principle (ISP)

### DIFF
--- a/Solid/InterfaceSegregationPrinciple/After-ISP.swift
+++ b/Solid/InterfaceSegregationPrinciple/After-ISP.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// Smaller, more specific interfaces
+protocol Order {
+    func placeOrder()
+    func processPayment()
+}
+
+protocol OnlineOrderFeatures {
+    func deliverToCustomer()
+    func sendEmailReceipt()
+}
+
+// Online order class conforming to both Order and OnlineOrderFeatures
+class OnlineOrder: Order, OnlineOrderFeatures {
+    func placeOrder() {
+        print("- Order placed online")
+    }
+
+    func processPayment() {
+        print("- Payment processed online")
+    }
+
+    func deliverToCustomer() {
+        print("- Order delivered to customer")
+    }
+
+    func sendEmailReceipt() {
+        print("- Email receipt sent to customer")
+    }
+}
+
+// In-store order class conforming only to the Order protocol
+class InStoreOrder: Order {
+    func placeOrder() {
+        print("- Order placed in store")
+    }
+
+    func processPayment() {
+        print("- Payment processed at the counter")
+    }
+}
+
+// Execute the code
+print("\nOnline order:")
+let onlineOrder = OnlineOrder()
+onlineOrder.placeOrder()
+onlineOrder.processPayment()
+onlineOrder.deliverToCustomer()
+onlineOrder.sendEmailReceipt()
+
+print("\nIn store order:")
+let inStoreOrder = InStoreOrder()
+inStoreOrder.placeOrder()
+inStoreOrder.processPayment()
+// No unnecessary methods for in-store orders

--- a/Solid/InterfaceSegregationPrinciple/Before-ISP.swift
+++ b/Solid/InterfaceSegregationPrinciple/Before-ISP.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// A single interface that both Online and InStore orders must conform to
+protocol Order {
+    func placeOrder()
+    func processPayment()
+    func deliverToCustomer() // Not applicable for in-store orders
+    func sendEmailReceipt() // Not applicable for in-store orders
+}
+
+// Online order class
+class OnlineOrder: Order {
+    func placeOrder () {
+        print("- Order placed online")
+    }
+
+    func processPayment() {
+        print("- Payment processed online")
+    }
+
+    func deliverToCustomer() {
+        print("- Order delivered to customer")
+    }
+
+    func sendEmailReceipt() {
+        print("- email receipt sent to customoer")
+    }
+}
+
+// In-store order class
+class InStoreOrder: Order {
+    func placeOrder() {
+        print("- Order placed in store")
+    }
+
+    func processPayment() {
+        print("- Payment processed at counter")
+    }
+
+    func deliverToCustomer() {
+        // In-store orders are picked up, so this method is not needed.
+        fatalError("- In-store orders cannot be delivered")
+    }
+
+    func sendEmailReceipt() {
+        // In-store orders provide printed receipts, so this method is not needed.
+        fatalError("- In-store orders do not send email receipts")
+    }
+}
+
+// Execute the code
+print("\nOnline order:")
+let onlineOrder = OnlineOrder()
+onlineOrder.placeOrder()
+onlineOrder.processPayment()
+onlineOrder.deliverToCustomer()
+onlineOrder.sendEmailReceipt()
+
+print("\nIn store order:")
+let inStoreOrder = InStoreOrder()
+inStoreOrder.placeOrder()
+inStoreOrder.processPayment()
+// inStoreOrder.deliverToCustomer() // This will crash as it is unintended functionality for in store orders
+// inStoreOrder.sendEmailReceipt() // This will crash as it is unintended functionality for in store orders

--- a/Solid/InterfaceSegregationPrinciple/ReadMe.md
+++ b/Solid/InterfaceSegregationPrinciple/ReadMe.md
@@ -1,0 +1,22 @@
+# Interface Segregation Principle (ISP)
+
+## What is ISP?
+The Interface Segregation Principle (ISP) is one of the SOLID principles of object-oriented design. It states that no client should be forced to depend on methods it does not use. In other words, larger interfaces should be split into smaller, more specific ones, so that implementing classes only need to be concerned with the methods that are relevant to them.
+
+## Before-ISP.swift
+In the `Before-ISP.swift` file, we have a single interface (`Order`) that contains methods for placing an order, processing payment, delivering the order to the customer, and sending an email receipt. Both online and in-store orders are required to implement this interface.
+
+### Issues:
+- **In-store orders** do not need to deliver to customers or send email receipts, but they still have to implement these methods. This leads to code that can cause runtime errors (e.g., using `fatalError` in methods that are not applicable).
+
+## After-ISP.swift
+In the `After-ISP.swift` file, the large interface is split into smaller, more specific interfaces:
+- `Order` contains methods common to all orders (`placeOrder`, `processPayment`).
+- `OnlineOrderFeatures` contains methods specific to online orders (`deliverToCustomer`, `sendEmailReceipt`).
+
+### Benefits:
+- **No unnecessary methods**: The `InStoreOrder` class only implements the methods it actually needs, avoiding the pitfalls of the earlier approach.
+- **Improved maintainability**: Code is more modular and easier to understand, reducing the likelihood of errors.
+
+## Summary
+By applying the Interface Segregation Principle, we create more focused interfaces that better represent the needs of different clients (in this case, different types of orders). This leads to more robust and maintainable code.


### PR DESCRIPTION
- Added `Before-ISP.swift` demonstrating violation of ISP with a single Order interface.
- Created `After-ISP.swift` adhering to ISP by splitting the interface into smaller, more specific ones.
- Added `ReadMe.md` to explain ISP, before/after changes, and benefits of the new design.