### PR TITLE
[Feature/Solid] Explain Dependency Inversion Principle (DIP)

### DIFF
--- a/Solid/DependencyInversionPrinciple/After-DIP.swift
+++ b/Solid/DependencyInversionPrinciple/After-DIP.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The high-level module now depends on an abstraction, making it easy to 
+/// switch between different payment processors without changing the PaymentService class.
+
+// Abstraction: Protocol defining the payment processing interface
+protocol PaymentProcessor {
+    func initiatePayment(of amount: Double)
+    func verifyPayment() -> Bool
+    func refundPayment(of amount: Double)
+}
+
+// Low-level module: Concrete implementation of PayPalPaymentProcessor adhering to the abstraction
+class PayPalPaymentProcessor: PaymentProcessor {
+    func initiatePayment(of amount: Double) {
+        print("- Initiating payment of $\(amount) using PayPal.")
+    }
+
+    func verifyPayment() -> Bool {
+        print("- Verifying payment using PayPal.")
+        return true
+    }
+
+    func refundPayment(of amount: Double) {
+        print("- Refunding $\(amount) using PayPal.")
+    }
+}
+
+// Low-level module: Another concrete implementation of a different payment processor
+class StripePaymentProcessor: PaymentProcessor {
+    func initiatePayment(of amount: Double) {
+        print("- Initiating payment of $\(amount) using Stripe.")
+    }
+
+    func verifyPayment() -> Bool {
+        print("- Verifying payment using Stripe.")
+        return true
+    }
+
+    func refundPayment(of amount: Double) {
+        print("- Refunding $\(amount) using Stripe.")
+    }
+}
+
+// High-level module: Payment Service that now depends on an abstraction
+class PaymentService {
+    // Adheres to DIP: High-level module depends on an abstraction
+    private let paymentProcessor: PaymentProcessor
+
+    init(paymentProcessor: PaymentProcessor) {
+        self.paymentProcessor = paymentProcessor
+    }
+
+    func processPayment(of amount: Double) {
+        paymentProcessor.initiatePayment(of: amount)
+        if paymentProcessor.verifyPayment() {
+            print("- Payment of $\(amount) processed successfully.")
+        }
+    }
+
+    func refundPayment(of amount: Double) {
+        paymentProcessor.refundPayment(of: amount)
+    }
+}
+
+let paypalProcessor = PayPalPaymentProcessor()
+let stripeProcessor = StripePaymentProcessor()
+
+let paymentService = PaymentService(paymentProcessor: paypalProcessor)
+paymentService.processPayment(of: 100)
+paymentService.refundPayment(of: 80)
+
+// Changing the processor without modifying the PaymentService
+let anotherPaymentService = PaymentService(paymentProcessor: stripeProcessor)
+anotherPaymentService.processPayment(of: 200.0)
+anotherPaymentService.refundPayment(of: 75.0)
+

--- a/Solid/DependencyInversionPrinciple/Before-DIP.swift
+++ b/Solid/DependencyInversionPrinciple/Before-DIP.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Voilatoin of Dependency Inversion Principle (DIP):
+/// The high-level module (PaymentService) is tightly coupled to the low-level module (PayPalPaymentProcessor). 
+/// This makes it hard to change or extend the payment processing logic without modifying the PaymentService class.
+/// If we need to add another payment processor let say `StripePaymentProcessor`, we will also to modify the existing
+/// `PaymentService` class to incorporate new payment processor. This would again voilate the Open/Closed Principle. 
+
+// Low-level module: Concrete payment processor
+class PayPalPaymentProcessor {
+    func initiatePayment(of amount: Double) {
+        print("- Initiating payment of $\(amount) using PayPal.")
+    }
+
+    func verifyPayment() -> Bool {
+        print("- Verifying payment using PayPal.")
+        return true
+    }
+
+    func refundPayment(of amount: Double) {
+        print("- Refunding $\(amount) using PayPal.")
+    }
+}
+
+// High-level module: Payment Service that uses PayPal directly
+class PaymentService {
+    private let paymentProcessor = PayPalPaymentProcessor()
+
+    func processPayment(of amount: Double) {
+        paymentProcessor.initiatePayment(of: amount)
+        if paymentProcessor.verifyPayment() {
+            print("- Payment of $\(amount) processed successfully.")
+        }
+    }
+
+    func refundPayment(of amount: Double) {
+        paymentProcessor.refundPayment(of: amount)
+    }
+}
+
+let paymentService = PaymentService()
+paymentService.processPayment(of: 100)
+paymentService.refundPayment(of: 80)

--- a/Solid/DependencyInversionPrinciple/ReadMe.md
+++ b/Solid/DependencyInversionPrinciple/ReadMe.md
@@ -1,0 +1,33 @@
+# What is the Dependency Inversion Principle (DIP)?
+
+The Dependency Inversion Principle is one of the five SOLID principles of object-oriented design. It suggests that:
+
+- High-level modules should not depend on low-level modules. Both should depend on abstractions.
+- Abstractions should not depend on details. Details should depend on abstractions.
+
+This principle is about inverting the direction of dependency. In traditional design, high-level modules (like business logic) often depend on low-level modules (like data access). DIP encourages us to make both high- and low-level modules depend on abstractions (e.g., interfaces or protocols). This leads to a more flexible and maintainable design where the implementation details can change without affecting the high-level logic.
+
+## Inversion in DIP:
+- The term "inversion" in DIP refers to the reversal of the conventional dependency direction. Typically, high-level modules depend on low-level modules. DIP inverts this by making both high-level and low-level modules depend on abstractions, reducing coupling and improving modularity.
+
+## High-Level vs. Low-Level Modules
+
+### High-Level Module:
+- This is a module that defines complex logic and policies. For example, in a payroll system, the high-level module might calculate salaries, bonuses, and deductions.
+
+### Low-Level Module:
+- This is a module that performs basic, detailed operations. For example, in the same payroll system, a low-level module might access the database to retrieve employee data or write transaction logs.
+
+
+In traditional design, the high-level module might directly depend on the low-level module, making it harder to change or extend the system.
+
+## Abstraction vs. Details
+
+### Abstraction:
+- This refers to the general, high-level concepts or interfaces that define what something does, not how it does it. For example, a protocol or interface that defines a method to send a notification is an abstraction.
+
+### Details:
+- This refers to the specific, low-level implementations that fulfill the abstraction. For example, an email service that sends notifications is a detail.
+
+
+According to DIP, high-level modules should depend on abstractions rather than concrete details. This way, the specifics of how something is done can be changed without affecting the broader logic.


### PR DESCRIPTION
- Added `Before-DIP.swift` demonstrating violation of DIP with direct dependency on low-level PayPalPaymentProcessor.
- Created `After-DIP.swift` implementing DIP by introducing a PaymentProcessor protocol.
- Refactored PaymentService to depend on an abstraction, allowing easy switching between different payment processors.
- Updated `ReadMe.md` to explain DIP, high/low-level modules, abstraction vs. details, and the concept of `inversion`.